### PR TITLE
Fix df errors when Dockerized

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+RUN sed -i '58s/-i//' /usr/local/share/perl/5.18.2/Mogstored/ChildProcess/DiskUsage.pm
 RUN  mkdir -p /etc/mogilefs \
   && mkdir -p /var/mogdata/dev1 \
   && mkdir -p /var/mogdata/dev2


### PR DESCRIPTION
The issue causes that mogstored cannot create usage file in /var/mogdata/dev1 and /var/mogdata/dev2, and let tracker cannot find free disk to write file. 

Ref the issue here: https://code.google.com/p/mogilefs/issues/detail?id=83